### PR TITLE
AR-2100 fixing error handling so that ioexceptions don't kill the entire...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.inin.analytics</groupId>
 	<artifactId>elasticsearch-lambda</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.4</version>
+	<version>1.0.5</version>
 	<name>elasticsearch-lambda</name>
 	<description>Framework For Lambda Architecture on Elasticsearch</description>
 	<url>https://github.com/drewdahlke/elasticsearch-lambda</url>

--- a/src/main/java/com/inin/analytics/elasticsearch/transport/HDFSSnapshotTransport.java
+++ b/src/main/java/com/inin/analytics/elasticsearch/transport/HDFSSnapshotTransport.java
@@ -1,5 +1,6 @@
 package com.inin.analytics.elasticsearch.transport;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.apache.commons.lang.StringUtils;
@@ -76,8 +77,8 @@ public class HDFSSnapshotTransport  extends BaseTransport {
 		ensurePathExists(destination);
 		try{
 			hdfsFileSystem.copyFromLocalFile(false, true, new Path(localShardPath), new Path(destination));	
-		} catch(IOException e) {
-			throw new IOException("Exception copying " + localShardPath + " to " + destination, e);
+		} catch(FileNotFoundException e) {
+			throw new FileNotFoundException("Exception copying " + localShardPath + " to " + destination);
 		} 
 	}
 


### PR DESCRIPTION
omit the failures from the manifest and log the fail. That way you can still make use of partial successes