### PR TITLE
AR-1853 bulk loading indexes into your ES cluster is faster if you build...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.inin.analytics</groupId>
 	<artifactId>elasticsearch-lambda</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.5</version>
+	<version>1.0.6</version>
 	<name>elasticsearch-lambda</name>
 	<description>Framework For Lambda Architecture on Elasticsearch</description>
 	<url>https://github.com/drewdahlke/elasticsearch-lambda</url>

--- a/src/main/java/com/inin/analytics/elasticsearch/BaseESReducer.java
+++ b/src/main/java/com/inin/analytics/elasticsearch/BaseESReducer.java
@@ -1,5 +1,6 @@
 package com.inin.analytics.elasticsearch;
 
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
@@ -59,6 +60,7 @@ public abstract class BaseESReducer implements Reducer<Text, Text, NullWritable,
 		numShardsPerIndex = new Integer(job.get(ConfigParams.NUM_SHARDS_PER_INDEX.toString()));
 		esBatchCommitSize = new Integer(job.get(ConfigParams.ES_BATCH_COMMIT_SIZE.toString()));
 	}
+	
 
 	private void init(String index) {
 		String templateName = getTemplateName();
@@ -79,7 +81,7 @@ public abstract class BaseESReducer implements Reducer<Text, Text, NullWritable,
 		esEmbededContainer = builder.build();
 		
 		// Create index
-		esEmbededContainer.getNode().client().admin().indices().prepareCreate(index).get();
+		esEmbededContainer.getNode().client().admin().indices().prepareCreate(index).setSettings(settingsBuilder().put("index.number_of_replicas", 0)).get();
 	}
 	
 	/**


### PR DESCRIPTION
... the indexes with no replicas and then set the # replicas to the desired number live on the server after loading it in