### PR TITLE
AR-2199 using copyFromLocalFile ignores the overwrite flag when the sour...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.inin.analytics</groupId>
 	<artifactId>elasticsearch-lambda</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.8</version>
+	<version>1.0.9</version>
 	<name>elasticsearch-lambda</name>
 	<description>Framework For Lambda Architecture on Elasticsearch</description>
 	<url>https://github.com/drewdahlke/elasticsearch-lambda</url>

--- a/src/test/java/com/inin/analytics/DateSerializerTest.java
+++ b/src/test/java/com/inin/analytics/DateSerializerTest.java
@@ -15,7 +15,7 @@ public class DateSerializerTest {
 	@Test
 	public void test() {
 		ElasticSearchIndexMetadata indexMetadata = new ElasticSearchIndexMetadata();
-		indexMetadata.setDate(new LocalDate());
+		indexMetadata.setDate(new LocalDate("2015-02-09"));
 		indexMetadata.setIndexNameAtBirth("test");
 		indexMetadata.setNumShards(2);
 		indexMetadata.setNumShardsPerOrg(3);


### PR DESCRIPTION
...ce is a directory which caused issues if a reduce task fails and is restarted. Copying 1 file at a time with overwrite=true should produce more consistant results