### PR TITLE
AR-2268 wasn't properly blocking waiting for the optimize to complete be...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.inin.analytics</groupId>
 	<artifactId>elasticsearch-lambda</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.11</version>
+	<version>1.0.12</version>
 	<name>elasticsearch-lambda</name>
 	<description>Framework For Lambda Architecture on Elasticsearch</description>
 	<url>https://github.com/drewdahlke/elasticsearch-lambda</url>


### PR DESCRIPTION
...fore snapshotting an index. While this was still functional, it produced index snapshots with a much larger # of files than ideal.