### PR TITLE
Ar 3053

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.inin.analytics</groupId>
 	<artifactId>elasticsearch-lambda</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.24</version>
+	<version>1.0.25</version>
 	<name>elasticsearch-lambda</name>
 	<description>Framework For Lambda Architecture on Elasticsearch</description>
 	<url>https://github.com/drewdahlke/elasticsearch-lambda</url>
@@ -198,7 +198,7 @@
 		<dependency>
 			<groupId>org.elasticsearch</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>1.4.4</version>
+			<version>1.6.0</version> 
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/inin/analytics/elasticsearch/ESEmbededContainer.java
+++ b/src/main/java/com/inin/analytics/elasticsearch/ESEmbededContainer.java
@@ -53,12 +53,14 @@ public class ESEmbededContainer {
 		TimeValue v = new TimeValue(timeoutMS);
 		for(String index : indicies) {
 			long start = System.currentTimeMillis();
-			// Flush before we determine # of segments that's ideal
+
+			// Flush
 			node.client().admin().indices().prepareFlush(index).get(v);
 			if(reporter != null) {
 				reporter.incrCounter(BaseESReducer.JOB_COUNTER.TIME_SPENT_FLUSHING_MS, System.currentTimeMillis() - start);
 			}
 
+			// Merge
 			start = System.currentTimeMillis();
 			node.client().admin().indices().prepareOptimize(index).get(v);
 			if(reporter != null) {


### PR DESCRIPTION
upgrading to ES 1.6, tuned segment merging to reduce # of segment files. This creates snapshots that can be restored faster. 

Note, the setWaitForMerge(true) option was removed in the more recent version. Still works fine