### PR TITLE
AR-5088: Use calling class ClassLoader instead of system ClassLoader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.inin.analytics</groupId>
 	<artifactId>elasticsearch-lambda</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1</version>
+	<version>1.2</version>
 	<name>elasticsearch-lambda</name>
 	<description>Framework For Lambda Architecture on Elasticsearch</description>
 	<url>https://github.com/drewdahlke/elasticsearch-lambda</url>

--- a/src/main/java/com/inin/analytics/elasticsearch/index/selector/RealtimeIndexSelectionStrategyLagged.java
+++ b/src/main/java/com/inin/analytics/elasticsearch/index/selector/RealtimeIndexSelectionStrategyLagged.java
@@ -44,7 +44,7 @@ public class RealtimeIndexSelectionStrategyLagged implements RealtimeIndexSelect
 		if(rotatedIndexMetadata != null && rotatedIndexMetadata.getRoutingStrategyClassName() != null && !rotatedIndexMetadata.getDate().isAfter(now.minusDays(LAG).toLocalDate())) {
 			ElasticsearchRoutingStrategy strategy;
 			try {
-				strategy = (ElasticsearchRoutingStrategy) Class.forName(rotatedIndexMetadata.getRoutingStrategyClassName(), true, ClassLoader.getSystemClassLoader()).newInstance();
+				strategy = (ElasticsearchRoutingStrategy) Class.forName(rotatedIndexMetadata.getRoutingStrategyClassName()).newInstance();
 				strategy.configure(rotatedIndexMetadata);
 				return strategy;
 			} catch (InstantiationException e) {


### PR DESCRIPTION
Applications launched with Spring Boot's [PropertiesLauncher](http://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/PropertiesLauncher.html) uses its own URLClassLoader instead of the system class loader. Using the calling class's class loader helps avoid using the wrong class loader.

Promoted to version 1.2.